### PR TITLE
Add capability to create coverage store with external files

### DIFF
--- a/src/geoserver/catalog.py
+++ b/src/geoserver/catalog.py
@@ -431,7 +431,7 @@ class Catalog(object):
         }
 
         cs_url = url(self.service_url,
-            ["workspaces", workspace, "coveragestores", name, "external." + extension], 
+            ["workspaces", workspace.name, "coveragestores", name, "external." + extension], 
             { "configure" : "first", "coverageName" : name})
         
         headers, response = self.http.request(cs_url, "PUT", url_filepath, headers)

--- a/src/geoserver/catalog.py
+++ b/src/geoserver/catalog.py
@@ -406,6 +406,12 @@ class Catalog(object):
                 unlink(archive)
 
     def create_coveragestore_external_geotiff(self, name, url_filepath, workspace=None, overwrite=False):
+        self._create_coveragestore_external(name, url_filepath, workspace, overwrite, extension="geotiff")
+        
+    def create_coveragestore_external_mosaic(self, name, url_filepath, workspace=None, overwrite=False):
+        self._create_coveragestore_external(name, url_filepath, workspace, overwrite, extension="imagemosaic")
+
+    def _create_coveragestore_external(self, name, url_filepath, workspace=None, overwrite=False, extension="geotiff"):
         if not overwrite:
             try:
                 self.get_store(name, workspace)
@@ -424,10 +430,8 @@ class Catalog(object):
             "Accept": "application/xml"
         }
 
-        ext = "geotiff"
-
         cs_url = url(self.service_url,
-            ["workspaces", workspace, "coveragestores", name, "external." + ext], 
+            ["workspaces", workspace, "coveragestores", name, "external." + extension], 
             { "configure" : "first", "coverageName" : name})
         
         headers, response = self.http.request(cs_url, "PUT", url_filepath, headers)

--- a/src/geoserver/catalog.py
+++ b/src/geoserver/catalog.py
@@ -385,10 +385,12 @@ class Catalog(object):
 
         if isinstance(data, dict):
             archive = prepare_upload_bundle(name, data)
-            message = archive
+            message = open(archive)
             if "tfw" in data:
                 headers['Content-type'] = 'application/archive'
                 ext = "worldimage"
+        elif isinstance(data, basestring):
+            message = open(data)
         else:
             message = data
 
@@ -396,11 +398,10 @@ class Catalog(object):
             ["workspaces", workspace.name, "coveragestores", name, "file." + ext])
 
         try:
-            with open(message, "rb") as f:
-                headers, response = self.http.request(cs_url, "PUT", f, headers)
-                self._cache.clear()
-                if headers.status != 201:
-                    raise UploadError(response)
+            headers, response = self.http.request(cs_url, "PUT", message, headers)
+            self._cache.clear()
+            if headers.status != 201:
+                raise UploadError(response)
         finally:
             if archive is not None:
                 unlink(archive)

--- a/src/geoserver/catalog.py
+++ b/src/geoserver/catalog.py
@@ -405,7 +405,7 @@ class Catalog(object):
             if archive is not None:
                 unlink(archive)
 
-    def create_coveragestore3(self, name, data, workspace=None, overwrite=False):
+    def create_coveragestore_external_geotiff(self, name, url_filepath, workspace=None, overwrite=False):
         if not overwrite:
             try:
                 self.get_store(name, workspace)
@@ -430,7 +430,7 @@ class Catalog(object):
             ["workspaces", workspace, "coveragestores", name, "external." + ext], 
             { "configure" : "first", "coverageName" : name})
         
-        headers, response = self.http.request(cs_url, "PUT", data, headers)
+        headers, response = self.http.request(cs_url, "PUT", url_filepath, headers)
         self._cache.clear()
         if headers.status != 201:
             raise UploadError(response)

--- a/src/geoserver/store.py
+++ b/src/geoserver/store.py
@@ -96,7 +96,8 @@ class CoverageStore(ResourceInfo):
     writers = dict(enabled = write_bool("enabled"),
                    name = write_string("name"),
                    url = write_string("url"),
-                   type = write_string("type"))
+                   type = write_string("type"),
+                   workspace = write_string("workspace"))
 
 
     def get_resources(self, name=None):
@@ -122,9 +123,9 @@ class UnsavedCoverageStore(CoverageStore):
     def __init__(self, catalog, name, workspace):
         super(UnsavedCoverageStore, self).__init__(catalog, workspace, name)
         self.dirty.update(name=name, enabled = True, type="GeoTIFF",
-                url = "file:data/")
+                url = "file:data/", workspace = workspace.name)
 
     @property
     def href(self):
         return url(self.catalog.service_url,
-            ["workspaces", self.workspace.name, "coveragestores"], dict(name=self.name))
+            ["workspaces", self.workspace.name, "coveragestores"])


### PR DESCRIPTION
I added two new public functions to add coverage store pointing to external data file (ie: not uploading the file to the GeoServer):

```
def create_coveragestore_external_geotiff(...)
def create_coveragestore_external_mosaic(...)
```
I've also fixed a problem where an UnsavedCoverageStore object would not be saved under the specified workspace, but rather the default workspace only (tested with GeoServer 2.4.2).