### PR TITLE
IMP LayerGroups and workspaces

### DIFF
--- a/src/geoserver/catalog.py
+++ b/src/geoserver/catalog.py
@@ -659,19 +659,30 @@ class Catalog(object):
         # TODO: Filter by style
         return lyrs
 
-    def get_layergroup(self, name=None):
+    def get_layergroup(self, name=None, workspace=None):
         try: 
-            group_url = url(self.service_url, ["layergroups", name + ".xml"])
+            path_parts = ["layergroups", name + ".xml"]
+            if workspace is not None:
+                wks_name = _name(workspace)
+                path_parts = ['workspaces', wks_name] + path_parts
+
+            group_url = url(self.service_url, path_parts)
             group = self.get_xml(group_url)
             return LayerGroup(self, group.find("name").text)
         except FailedRequestError:
             return None
 
-    def get_layergroups(self):
-        groups = self.get_xml("%s/layergroups.xml" % self.service_url)
+    def get_layergroups(self, workspace=None):
+        path_parts = ['layergroups.xml']
+        if workspace is not None:
+            wks_name = _name(workspace)
+            path_parts = ['workspaces', wks_name] + path_parts
+
+        groups_url = url(self.service_url, path_parts)
+        groups = self.get_xml(groups_url)
         return [LayerGroup(self, g.find("name").text) for g in groups.findall("layerGroup")]
 
-    def create_layergroup(self, name, layers = (), styles = (), bounds = None):
+    def create_layergroup(self, name, layers = (), styles = (), bounds = None, workspace = None):
         if any(g.name == name for g in self.get_layergroups()):
             raise ConflictingDataError("LayerGroup named %s already exists!" % name)
         else:

--- a/src/geoserver/catalog.py
+++ b/src/geoserver/catalog.py
@@ -668,7 +668,8 @@ class Catalog(object):
 
             group_url = url(self.service_url, path_parts)
             group = self.get_xml(group_url)
-            return LayerGroup(self, group.find("name").text)
+            wks_name = group.find("workspace").find("name").text
+            return LayerGroup(self, group.find("name").text, wks_name)
         except FailedRequestError:
             return None
 
@@ -686,7 +687,8 @@ class Catalog(object):
         if any(g.name == name for g in self.get_layergroups()):
             raise ConflictingDataError("LayerGroup named %s already exists!" % name)
         else:
-            return UnsavedLayerGroup(self, name, layers, styles, bounds)
+            return UnsavedLayerGroup(self, name, layers, styles, bounds,
+                                     workspace)
 
     def get_style(self, name, workspace=None):
         '''Find a Style in the catalog if one exists that matches the given name.

--- a/src/geoserver/catalog.py
+++ b/src/geoserver/catalog.py
@@ -681,7 +681,7 @@ class Catalog(object):
 
         groups_url = url(self.service_url, path_parts)
         groups = self.get_xml(groups_url)
-        return [LayerGroup(self, g.find("name").text) for g in groups.findall("layerGroup")]
+        return [LayerGroup(self, g.find("name").text, wks_name) for g in groups.findall("layerGroup")]
 
     def create_layergroup(self, name, layers = (), styles = (), bounds = None, workspace = None):
         if any(g.name == name for g in self.get_layergroups()):

--- a/src/geoserver/layergroup.py
+++ b/src/geoserver/layergroup.py
@@ -67,7 +67,8 @@ class LayerGroup(ResourceInfo):
             name = write_string("name"),
             styles = _write_styles,
             layers = lambda b,l: _write_layers(b, l, parent, element, attributes),
-            bounds = write_bbox("bounds")
+            bounds = write_bbox("bounds"),
+            workspace = write_string("workspace")
         )
 
     @property
@@ -106,7 +107,7 @@ class LayerGroup(ResourceInfo):
 class UnsavedLayerGroup(LayerGroup):
     save_method = "POST"
     def __init__(self, catalog, name, layers, styles, bounds, workspace):
-        super(UnsavedLayerGroup, self).__init__(catalog, name)
+        super(UnsavedLayerGroup, self).__init__(catalog, name, workspace=workspace)
         bounds = bounds if bounds is not None else ("-180","180","-90","90","EPSG:4326")
         self.dirty.update(name = name, layers = layers, styles = styles,
                           bounds = bounds, workspace = workspace)


### PR DESCRIPTION
* Now we can use workspace parameter in `get_layergroups` and `get_layer` to
  return layergroups in a workspace.
* `workspace` attribute may be set to create a layergroup
* `workspace` attribute is now readable in a LayerGroup object

test functions must be updated. Any suggestions?