### PR TITLE
write password correctly when creating storage

### DIFF
--- a/examples/postgis_import.py
+++ b/examples/postgis_import.py
@@ -10,7 +10,7 @@ ds.connection_parameters.update(
     port="5432",
     database="gis",
     user="postgres",
-    password="",
+    passwd="",
     dbtype="postgis")
 
 cat.save(ds)


### PR DESCRIPTION
password should be passwd otherwise the password is not set in the datastore