### PR TITLE
Adapted unittests tests to use external GS and PG

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
     - python: "2.6"
       env: GS_VERSION=2.7.x
     - python: "2.6"
-      env: GS_VERSION=master
+      env: GS_VERSION=2.8.x
     - python: "2.7"
       env: GS_VERSION=2.4.x
     - python: "2.7"
@@ -24,7 +24,7 @@ matrix:
     - python: "2.7"
       env: GS_VERSION=2.7.x
     - python: "2.7"
-      env: GS_VERSION=master
+      env: GS_VERSION=2.8.x
 install:
   - sudo apt-get -qq -y update
   - sudo apt-get install -y --force-yes openjdk-7-jdk --no-install-recommends

--- a/test/catalogtests.py
+++ b/test/catalogtests.py
@@ -1,21 +1,24 @@
-import os, subprocess, atexit, signal, tempfile
+import os
+import subprocess
+import atexit
+import signal
+import tempfile
 import time
 import re
 import unittest
 import gisdata
-from geoserver.catalog import Catalog, ConflictingDataError, UploadError, \
-    FailedRequestError
+from geoserver.catalog import Catalog
+from geoserver.catalog import ConflictingDataError
+from geoserver.catalog import UploadError
+from geoserver.catalog import FailedRequestError
 from geoserver.support import ResourceInfo, url
 from geoserver.support import DimensionInfo
-from geoserver.support import JDBCVirtualTable, JDBCVirtualTableGeometry, JDBCVirtualTableParam
+from geoserver.support import JDBCVirtualTable
+from geoserver.support import JDBCVirtualTableGeometry
 from geoserver.layergroup import LayerGroup
 from geoserver.util import shapefile_and_friends
-
-DBPARAMS = dict(host="localhost", port="5432", dbtype="postgis",
-    database=os.getenv("DATABASE", "db"),
-    user=os.getenv("DBUSER", "postgres"),
-    passwd=os.getenv("DBPASS", "password")
-)
+from utils import DBPARAMS
+from utils import GSPARAMS
 
 try:
     import psycopg2
@@ -27,37 +30,37 @@ except ImportError:
     pass
 
 # support resetting geoserver datadir
-GEOSERVER_HOME = os.getenv('GEOSERVER_HOME')
-if GEOSERVER_HOME:
-    dest = os.getenv('DATA_DIR')
-    data = os.path.join(GEOSERVER_HOME, 'data/release', '')
+if GSPARAMS['GEOSERVER_HOME']:
+    dest = GSPARAMS['DATA_DIR']
+    data = os.path.join(GSPARAMS['GEOSERVER_HOME'], 'data/release', '')
     if dest:
-        os.system('rsync -v -a --delete %s %s' % (data, os.path.join(dest, '')))
+        os.system('rsync -v -a --delete %s %s' %
+                  (data, os.path.join(dest, '')))
     else:
         os.system('git clean -dxf -- %s' % data)
-    os.system('curl -XPOST --user admin:geoserver http://localhost:8080/geoserver/rest/reload')
+    os.system('curl -XPOST --user '+GSPARAMS['GSUSER']+':' +
+              GSPARAMS['GSPASSWORD']+' '+GSPARAMS['GSURL']+'/reload')
 
 # set GS_VERSION to None in order to skip the GeoServer setup
 global child_pid
 GS_BASE_DIR = tempfile.gettempdir()
 # use "master" in order to test against the latest GeoServer version
-GS_VERSION = os.getenv('GS_VERSION') if os.getenv('GS_VERSION') else None
-if GS_VERSION:
-    subprocess.Popen(["rm", "-rf", GS_BASE_DIR + "/gs"]).communicate()
-    subprocess.Popen(["mkdir", GS_BASE_DIR + "/gs"]).communicate()
+if GSPARAMS['GS_VERSION']:
+    subprocess.Popen(["rm", "-rf", GSPARAMS['GS_BASE_DIR'] + "/gs"]).communicate()
+    subprocess.Popen(["mkdir", GSPARAMS['GS_BASE_DIR'] + "/gs"]).communicate()
     subprocess.Popen(["wget",
                       "http://repo2.maven.org/maven2/org/mortbay/jetty/jetty-runner/8.1.8.v20121106/jetty-runner-8.1.8.v20121106.jar",
-                      "-P", GS_BASE_DIR + "/gs"]).communicate()
+                      "-P", GSPARAMS['GS_BASE_DIR'] + "/gs"]).communicate()
     subprocess.Popen(["wget",
-                      "http://ares.boundlessgeo.com/geoserver/" + GS_VERSION +"/geoserver-" + GS_VERSION + "-latest-war.zip",
-                      "-P", GS_BASE_DIR + "/gs"]).communicate()
-    subprocess.Popen(["unzip", "-o", "-d", GS_BASE_DIR + "/gs",
-                      GS_BASE_DIR + "/gs/geoserver-" + GS_VERSION + "-latest-war.zip"]).communicate()
+                      "http://ares.boundlessgeo.com/geoserver/" + GSPARAMS['GS_VERSION'] +"/geoserver-" + GSPARAMS['GS_VERSION'] + "-latest-war.zip",
+                      "-P", GSPARAMS['GS_BASE_DIR'] + "/gs"]).communicate()
+    subprocess.Popen(["unzip", "-o", "-d", GSPARAMS['GS_BASE_DIR'] + "/gs",
+                      GSPARAMS['GS_BASE_DIR'] + "/gs/geoserver-" + GSPARAMS['GS_VERSION'] + "-latest-war.zip"]).communicate()
     FNULL = open(os.devnull, 'w')
     proc = subprocess.Popen(["java", "-Xmx512m", "-XX:MaxPermSize=256m",
                              "-Dorg.eclipse.jetty.server.webapp.parentLoaderPriority=true",
-                             "-jar", GS_BASE_DIR + "/gs/jetty-runner-8.1.8.v20121106.jar",
-                             "--path", "/geoserver", GS_BASE_DIR + "/gs/geoserver.war"],
+                             "-jar", GSPARAMS['GS_BASE_DIR'] + "/gs/jetty-runner-8.1.8.v20121106.jar",
+                             "--path", "/geoserver", GSPARAMS['GS_BASE_DIR'] + "/gs/geoserver.war"],
                              stdout=FNULL, stderr=subprocess.STDOUT)
     child_pid = proc.pid
     print "Sleep (90)..."
@@ -67,7 +70,7 @@ def kill_child():
     if child_pid is None:
         pass
     else:
-        subprocess.Popen(["rm", "-Rf", GS_BASE_DIR + "/gs"]).communicate()
+        subprocess.Popen(["rm", "-Rf", GSPARAMS['GS_BASE_DIR'] + "/gs"]).communicate()
         print "KILLING PROCESS: " + str(child_pid)
         os.kill(child_pid, signal.SIGTERM)
 
@@ -108,7 +111,7 @@ class NonCatalogTests(unittest.TestCase):
 
 class CatalogTests(unittest.TestCase):
     def setUp(self):
-        self.cat = Catalog("http://localhost:8080/geoserver/rest")
+        self.cat = Catalog(GSPARAMS['GSURL'], username=GSPARAMS['GSUSER'], password=GSPARAMS['GSPASSWORD'])
 
     def testAbout(self):
         about_html = self.cat.about()
@@ -303,7 +306,7 @@ class CatalogTests(unittest.TestCase):
 class ModifyingTests(unittest.TestCase):
 
     def setUp(self):
-        self.cat = Catalog("http://localhost:8080/geoserver/rest")
+        self.cat = Catalog(GSPARAMS['GSURL'], username=GSPARAMS['GSUSER'], password=GSPARAMS['GSPASSWORD'])
 
     def testFeatureTypeSave(self):
         # test saving round trip
@@ -429,7 +432,7 @@ class ModifyingTests(unittest.TestCase):
         jdbc_vt = JDBCVirtualTable(ft_name, sql, 'false', geom, keyColumn, parameters)
         ft = self.cat.publish_featuretype(ft_name, store, epsg_code, jdbc_virtual_table=jdbc_vt)
 
-    # DISABLED; this test works only in the very particular case 
+    # DISABLED; this test works only in the very particular case
     # "mytiff.tiff" is already present into the GEOSERVER_DATA_DIR
     # def testCoverageStoreCreate(self):
     #     ds = self.cat.create_coveragestore2("coverage_gsconfig")

--- a/test/catalogtests.py
+++ b/test/catalogtests.py
@@ -43,6 +43,7 @@ if GSPARAMS['GEOSERVER_HOME']:
 
 # set GS_VERSION to None in order to skip the GeoServer setup
 global child_pid
+child_pid = None
 GS_BASE_DIR = tempfile.gettempdir()
 # use "master" in order to test against the latest GeoServer version
 if GSPARAMS['GS_VERSION']:

--- a/test/utils.py
+++ b/test/utils.py
@@ -1,0 +1,62 @@
+"""utils to centralize global variabl settings configurable by env vars."""
+import os
+
+# envs that can be override by os.environ envs
+GSHOSTNAME = 'localhost'
+GSPORT = '8080'
+GSSSHPORT = '8443'
+GSUSER = 'admin'
+GSPASSWORD = 'geoserver'
+
+
+def geoserverLocation():
+    """get GSHOSTNAME and GSPORT or use default localhost:8080."""
+    server = GSHOSTNAME
+    port = GSPORT
+    server = os.getenv('GSHOSTNAME', server)
+    port = os.getenv('GSPORT', port)
+    return '%s:%s' % (server, port)
+
+
+def geoserverLocationSsh():
+    """get GSSSHPORT and GSSSHPORT or use default localhost:8443."""
+    location = geoserverLocation().split(":")[0]
+    sshport = GSSSHPORT
+    sshport = os.getenv('GSSSHPORT', sshport)
+    return '%s:%s' % (location, sshport)
+
+
+def serverLocationBasicAuth():
+    """Set server URL for http connection."""
+    return "http://"+geoserverLocation()+"/geoserver"
+
+
+def serverLocationPkiAuth():
+    """Set server URL for https connection."""
+    return "https://"+geoserverLocationSsh()+"/geoserver"
+
+
+GSPARAMS = dict(
+    GSURL=serverLocationBasicAuth()+'/rest',
+    GSUSER=GSUSER,
+    GSPASSWORD=GSPASSWORD,
+    GEOSERVER_HOME='',
+    DATA_DIR='',
+    GS_VERSION='',
+    GS_BASE_DIR=''
+)
+GSPARAMS.update([(k, os.getenv(k)) for k in GSPARAMS if k in os.environ])
+
+DBPARAMS = dict(
+    host=os.getenv("DBHOST", "localhost"),
+    port=os.getenv("DBPORT", "5432"),
+    dbtype=os.getenv("DBTYPE", "postgis"),
+    database=os.getenv("DATABASE", "db"),
+    user=os.getenv("DBUSER", "postgres"),
+    passwd=os.getenv("DBPASS", "password")
+)
+print '*** GSPARAMS ***'
+print GSPARAMS
+print '*** DBPARAMS ***'
+print DBPARAMS
+print '****************'


### PR DESCRIPTION
This simplify testing in a dockerised context. e.g setting an IP for GS and a different IP for PG.

this PL has been tested against:
- master geoserver in a docker contaner
- postgis in another container

default conf is to point to localhost, bat configuration can be overrided using env vars:
GS env vars
    GSURL (new)
    GSUSER (new)
    GSPASSWORD (new)
    GEOSERVER_HOME (new)
    DATA_DIR
    GS_VERSION
    GS_BASE_DIR

PD env vars
    DBHOST (new)
    DBPORT (new)
    DBTYPE (new)
    DATABASE
    DBUSER
    DBPASS

Env var settings has bee centralised into usitls.py

also fixed a test with syntax error.

NOTE: remain a failing test that was incorrectly wrote 

======================================================================

ERROR: testCoverageCreate (test.catalogtests.ModifyingTests)

----------------------------------------------------------------------

Traceback (most recent call last):
  File "catalogtests.py", line 632, in testCoverageCreate
    ft_ext = self.cat.create_coveragestore_external_geotiff("Pk50095_ext", 'file:test/data/Pk50095.tif', sf)
  File "catalog.py", line 477, in create_coveragestore_external_geotiff
    self._create_coveragestore(name, data, workspace=workspace, overwrite=overwrite, external=True)
  File "catalog.py", line 534, in _create_coveragestore
    raise UploadError(response)
UploadError: Failed to locate the input file file:test/data/Pk50095.tif

----------------------------------------------------------------------
