### PR TITLE
version 1.0.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ except IOError,e:
     readme_text = ''
 
 setup(name = "gsconfig",
-    version = "1.0.4",
+    version = "1.0.6",
     description = "GeoServer REST Configuration",
     long_description = readme_text,
     keywords = "GeoServer REST Configuration",


### PR DESCRIPTION
A version 1.0.5 may have been previously uploaded to PyPI, creating various
possibilities for difficulty or confusion if we try to upload a different
release with that version number. So we're just going with 1.0.6