### PR TITLE
Add support for coverage parameters

### DIFF
--- a/src/geoserver/resource.py
+++ b/src/geoserver/resource.py
@@ -8,8 +8,8 @@ __author__ = "David Winslow"
 __copyright__ = "Copyright 2012-2015 Boundless, Copyright 2010-2012 OpenPlans"
 __license__ = "MIT"
 
-from geoserver.support import ResourceInfo, DimensionInfo, xml_property, write_string, bbox, metadata, \
-    write_metadata, write_bbox, string_list, write_string_list, attribute_list, write_bool, url
+from geoserver.support import ResourceInfo, DimensionInfo, xml_property, write_string, bbox, metadata, coverage_parameters_list, \
+    write_metadata, write_bbox, string_list, write_string_list, attribute_list, write_bool, url, write_coverage_parameters_list
 
 def md_link(node):
     """Extract a metadata link tuple from an xml node"""
@@ -202,6 +202,7 @@ class Coverage(_ResourceBase):
     supported_formats = xml_property("supportedFormats", string_list)
     metadata_links = xml_property("metadataLinks", metadata_link_list)
     metadata = xml_property("metadata", metadata)
+    parameters = xml_property("parameters", coverage_parameters_list)
 
     writers = dict(
                 title = write_string("title"),
@@ -217,7 +218,8 @@ class Coverage(_ResourceBase):
                 requestSRS = write_string_list("requestSRS"),
                 responseSRS = write_string_list("responseSRS"),
                 supportedFormats = write_string_list("supportedFormats"),
-                metadata = write_metadata("metadata")
+                metadata = write_metadata("metadata"),
+                parameters = write_coverage_parameters_list("parameters")
             )
 
 class WmsLayer(ResourceInfo):

--- a/test/catalogtests.py
+++ b/test/catalogtests.py
@@ -877,6 +877,42 @@ class ModifyingTests(unittest.TestCase):
         self.cat.delete(store, purge=True, recurse=True)
         self.cat._cache.clear()
 
+    def testImageMosaicParameters(self):
+        # testing the mosaic creation
+        name = 'c_mosaic'
+        data = open('test/data/mosaic/cea.zip', 'rb')
+        self.cat.create_imagemosaic(name, data)
+
+        # get the resource back
+        self.cat._cache.clear()
+        resource = self.cat.get_resource(name)
+
+        self.assert_(resource is not None)
+
+        # get parameters
+        parameters = resource.parameters
+        self.assert_(isinstance(parameters, list))
+
+        def find_parameter_index(parameters, param_name):
+            indexes = [index for index in range(len(parameters)) if parameters[index][0]["value"] == param_name]
+            if len(indexes) > 0:
+                return indexes[0]
+            return None
+
+        # update parameters, save, and fetch to see if updated
+        idx = find_parameter_index(parameters, "SUGGESTED_TILE_SIZE")
+        parameters[idx][1]["value"] = "256,256"
+        resource.parameters = parameters
+        self.cat.save(resource)
+
+
+         # get the resource back
+        self.cat._cache.clear()
+        resource = self.cat.get_resource(name)
+        parameters = resource.parameters
+        idx = find_parameter_index(parameters, "SUGGESTED_TILE_SIZE")
+        self.assert_(parameters[idx][1]["value"] == "256,256")
+
     def testTimeDimension(self):
         sf = self.cat.get_workspace("sf")
         files = shapefile_and_friends(os.path.join(gisdata.GOOD_DATA, "time", "boxes_with_end_date"))


### PR DESCRIPTION
This PR adds support for reading and writing Coverage parameters via geoserver REST API.
It's important to mention that I'm not familiar with geoserver internals, nor with JAVA, so be careful when you review my type conversions.

Note: Currently there is a [bug ](https://osgeo-org.atlassian.net/projects/GEOS/issues/GEOS-8745?filter=allopenissues) that causes Coverage parameter types to be wrong when created via the API.